### PR TITLE
PW 937 fix onError not returning error object when widget is closed

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -385,7 +385,7 @@ class API {
   // eslint-disable-next-line camelcase
   _closeWidgetWithError(error_type, message) {
     this._closeWidget();
-    this._triggerCallback(CALLBACK_ERROR, { error_type, message });
+    this._triggerCallback(CALLBACK_ERROR, { error: { error_type, message } });
   }
 
   _closeWidget() {


### PR DESCRIPTION
Closing the widget no longer returns the error object in the onError callback. I think it has to do with [this change](https://github.com/wealthica/wealthica-sdk-js/commit/d6e50a58b62cd66ddecf49fca26b2a2650779771#diff-d45b1674ab37689f6ca6dc634fe29959c463fc30cb46746c3b187de88432ae4fR341).

Basically _triggerCallback expects an `{ error }` inside the message payload. But [_closeWidgetWithError](https://github.com/wealthica/wealthica-sdk-js/blame/bbb6abcec33346cd3caaf7afe0f2803df8d95bd5/src/api.js#L386) hasn't been updated yet