### PR TITLE
[WP-1164] Document release process in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,14 @@ ESLint with `airbnb-base`. `no-underscore-dangle` is disabled (private methods u
 
 ## Release Process
 
-```
-npm version patch  # or minor/major
+Published to npm as `wealthica-sdk-js` (see `name` in `package.json`).
+
+```bash
+npm version patch        # or minor / major
 git push && git push --tags
-npm publish
+npm publish              # `prepublishOnly` runs the build automatically
 ```
+
+Verify the new version is live on https://www.npmjs.com/package/wealthica-sdk-js.
+
+There is no separate staging environment for this package — every published version is available to all consumers. Test changes locally with `npm link` or by pointing a consumer at a tarball before publishing.


### PR DESCRIPTION
## Summary
Documents the release process for this repo in `CLAUDE.md` so future Claude Code sessions know how to release safely.

- Expanded the existing minimal `npm version` / `npm publish` snippet to the full Pattern 6 template
- Added `prepublishOnly` note, npm verify URL, and no-staging caveat

Part of [WP-1164](https://app.clickup.com/t/86exqhhda) — standardizing release-process docs across all active Wealthica / Vezgo / Stockchase repos.